### PR TITLE
Potential fix for code scanning alert no. 16: Clear-text logging of sensitive information

### DIFF
--- a/scikitplot/sp_logging.py
+++ b/scikitplot/sp_logging.py
@@ -1294,7 +1294,8 @@ def warning(msg, *args, **kwargs):
     kwargs : any
         Additional keyword arguments for logging.
     """
-    get_logger().warning(msg, *args, **kwargs)
+    sanitized_msg = sanitize_sensitive_data(msg)
+    get_logger().warning(sanitized_msg, *args, **kwargs)
 
 
 ######################################################################

--- a/scikitplot/utils/utils_st_secrets.py
+++ b/scikitplot/utils/utils_st_secrets.py
@@ -46,7 +46,7 @@ def load_st_secrets(
         try:
             return read_toml(path)
         except ScikitplotException as e:
-            logger.warning(f"Could not load secrets from {path}: {e}")
+            logger.warning(f"Could not load secrets from {os.path.basename(path)}: {e}")
     return {}
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/scikit-plots/scikit-plots/security/code-scanning/16](https://github.com/scikit-plots/scikit-plots/security/code-scanning/16)

To fix the issue, we need to ensure that sensitive data, such as paths to secrets files, is not logged in clear text. Instead, we can sanitize the data before logging or avoid logging it altogether. Specifically:
1. Modify the `warning` function in `scikitplot/sp_logging.py` to sanitize or redact sensitive information in the `msg` parameter before logging.
2. Update the `resolve_secret_path` and related functions in `scikitplot/utils/utils_st_secrets.py` to avoid passing sensitive paths directly to logging functions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
